### PR TITLE
BUGFIX import() method breaks on no association defined

### DIFF
--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressRelationsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressRelationsRoutine.php
@@ -48,8 +48,8 @@ class ImportExpressRelationsRoutine extends AbstractRoutine
                             if (is_object($target_entity)) {
                                 $association->setTargetEntity($target_entity);
                             }
+                            $em->persist($association);
                         }
-                        $em->persist($association);
                     }
                 }
             }


### PR DESCRIPTION
swapped line 51 and 52:  $em->persist($association); 
this makes no sense outside the "if" block